### PR TITLE
Add test for input

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,6 +34,8 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
 
 [targets]
-test = ["Pkg", "Plots", "PyPlot", "Test", "VisualRegressionTests", "ImageIO", "ImageMagick"]
+test = ["Pkg", "Plots", "PyPlot", "Test", "VisualRegressionTests", "ImageIO", "ImageMagick", "Distributions", "HypothesisTests"]

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -1,6 +1,6 @@
 @testset "ConstantRate" begin
     T = 10_000
-    freq = rand()
+    freq = rand(1:100)
     dt = rand() * (1/freq)
     rate = freq * dt
     input = ConstantRate(rate)

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -2,66 +2,95 @@ using SpikingNN
 using Statistics
 using Test
 
-@testset "LIF spike count" begin
-    # LIF params
-    τm = 100
-    vreset = 0.0
-    vth = 0.1
-    R = 1.75
+@testset "input" begin
 
-    # Input spike train params
-    rate = 0.05
-    T = 1000
+    @testset "LIF SpikeCount" begin
+        # LIF params
+        τm = 100
+        vreset = 0.0
+        vth = 0.1
+        R = 1.75
 
-    lif = Neuron(QueuedSynapse(Synapse.Delta()), LIF(τm, vreset, R), Threshold.Ideal(vth))
-    input = ConstantRate(rate)
+        # Input spike train params
+        rate = 0.05
+        T = 1000
+
+        lif = Neuron(QueuedSynapse(Synapse.Delta()), LIF(τm, vreset, R), Threshold.Ideal(vth))
+        input = ConstantRate(rate)
 
 
-    spikescount = []
-    for i in 1:T
-        spikes = excite!(lif, input, T)
-        push!(spikescount, length(spikes))
+        spikescount = []
+        for i in 1:T
+            spikes = excite!(lif, input, T)
+            push!(spikescount, length(spikes))
+        end
+
+        avgspikecount = mean(spikescount)/T
+
+
+        @test Float32(round(avgspikecount,digits = 2)) == input.rate
     end
 
-    avgspikecount = mean(spikescount)/T
+    @testset "SRM SpikeCount" begin
+
+        # SRM0 params
+        η₀ = 5.0
+        τᵣ = 1.0
+        vth = 0.5
+
+        # Input spike train params
+        rate = 0.01
+        T = 1000
+
+        srm = Neuron(QueuedSynapse(Synapse.Alpha()), SRM0(η₀, τᵣ), Threshold.Ideal(vth))
+        input = ConstantRate(rate)
 
 
-    @test Float32(round(avgspikecount,digits = 2)) == input.rate
+        spikescount = []
+        for i in 1:T
+            spikes = excite!(srm, input, T)
+            push!(spikescount, length(spikes))
+        end
+
+        avgspikecount = mean(spikescount)/T
+
+        @test Float32(round(avgspikecount,digits = 2)) == input.rate
+        
+    end
+
+   # Assert frequency constructor matches the rate constructor
+   @testset "ConstantRate Constructor" begin
+
+    freq = 0.05
+    dt = 1.0
+    rate = freq * dt
+
+    @test ConstantRate(freq, dt).rate == ConstantRate(rate).rate
+
+    end
+
+    @testset "StepCurrent" begin
+
+        τ = 10
+
+        stepcurrent = StepCurrent(τ)
+
+        let
+            flag = true
+
+            for t in 0:100
+                if t <= τ
+                    evaluate!(stepcurrent, t) != 0 ? flag = false : flag = true
+                        
+                else
+                    (evaluate!(stepcurrent, t) > 0) != true ? flag = false : flag = true
+                end
+            end     
+
+            @test flag == true
+        end
+    end
+
+
 end
 
-@testset "SRM0 spike count" begin
-
-    # SRM0 params
-    η₀ = 5.0
-    τᵣ = 1.0
-    vth = 0.5
-
-    # Input spike train params
-    rate = 0.01
-    T = 1000
-
-    srm = Neuron(QueuedSynapse(Synapse.Alpha()), SRM0(η₀, τᵣ), Threshold.Ideal(vth))
-    input = ConstantRate(rate)
-
-
-    spikescount = []
-    for i in 1:T
-        spikes = excite!(srm, input, T)
-        push!(spikescount, length(spikes))
-    end
-
-    avgspikecount = mean(spikescount)/T
-
-
-    @test Float32(round(avgspikecount,digits = 2)) == input.rate
-
-    
-    # Assert frequency constructor matches the rate constructor
-    @test begin
-        freq = 0.05
-        dt = 1.0
-        rate = freq * dt
-
-        ConstantRate(freq, dt).rate == ConstantRate(rate).rate
-    end
-end

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -1,0 +1,58 @@
+using SpikingNN
+using Statistics
+using Test
+
+@testset "LIF spike count" begin
+    # LIF params
+    τm = 100
+    vreset = 0.0
+    vth = 0.1
+    R = 1.75
+
+    # Input spike train params
+    rate = 0.05
+    T = 1000
+
+    lif = Neuron(QueuedSynapse(Synapse.Delta()), LIF(τm, vreset, R), Threshold.Ideal(vth))
+    input = ConstantRate(rate)
+
+
+    spikescount = []
+    for i in 1:T
+        spikes = excite!(lif, input, T)
+        push!(spikescount, length(spikes))
+    end
+
+    avgspikecount = mean(spikescount)/T
+
+
+    @test Float32(round(avgspikecount,digits = 2)) == input.rate
+end
+
+@testset "SRM0 spike count" begin
+
+    # SRM0 params
+    η₀ = 5.0
+    τᵣ = 1.0
+    vth = 0.5
+
+    # Input spike train params
+    rate = 0.01
+    T = 1000
+
+    srm = Neuron(QueuedSynapse(Synapse.Alpha()), SRM0(η₀, τᵣ), Threshold.Ideal(vth))
+    input = ConstantRate(rate)
+
+
+    spikescount = []
+    for i in 1:T
+        spikes = excite!(srm, input, T)
+        push!(spikescount, length(spikes))
+    end
+
+    avgspikecount = mean(spikescount)/T
+
+
+    @test Float32(round(avgspikecount,digits = 2)) == input.rate
+end
+

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -54,5 +54,14 @@ end
 
 
     @test Float32(round(avgspikecount,digits = 2)) == input.rate
-end
 
+    
+    # Assert frequency constructor matches the rate constructor
+    @test begin
+        freq = 0.05
+        dt = 1.0
+        rate = freq * dt
+
+        ConstantRate(freq, dt).rate == ConstantRate(rate).rate
+    end
+end

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -1,17 +1,13 @@
-# Averaging the spike count of ConstantRate over a fixed window of time should be ConstantRate.rate
 @testset "ConstantRate" begin
     T = 10_000
-    rate = rand()
-    input = ConstantRate(rate)
-    @test isapprox(count(x -> x > 0, [input(t) for t in 1:T]) / T, rate, atol=0.005)
-end
-
-# Assert frequency constructor matches the rate constructor
-@testset "ConstantRate Constructors" begin
     freq = rand()
-    freq == 0.01 ? dt = rand() * 0.01 : dt = rand()
+    dt = rand() * (1/freq)
     rate = freq * dt
-    @test ConstantRate(freq, dt).rate == ConstantRate(rate).rate
+    input = ConstantRate(rate)
+    # Averaging the spike count of ConstantRate over a fixed window of time should be ConstantRate.rate
+    @test isapprox(count(x -> x > 0, [input(t) for t in 1:T]) / T, rate, atol=0.005)
+    # Assert frequency constructor matches the rate constructor
+    @test ConstantRate(freq, dt).rate == input.rate
 end
 
 # A StepCurrent should be zero < threshold time and positive > threshold time

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -23,7 +23,7 @@ end
 end
 
 # The spikes of a inhomogeneous Poisson input with a constant λ should be distributed as a Poisson process
-@testskip @testset "PoissonInput" begin
+@test_skip @testset "PoissonInput" begin
     ρ₀ = 0.1
     λ = 0.2
     pI = PoissonInput(ρ₀, (t; dt) -> λ)

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -21,3 +21,20 @@ end
     @test all(x -> x == 0, prethresh)
     @test all(x -> x > 0, postthresh)    
 end
+
+# The spikes of a inhomogeneous Poisson input with a constant λ should be distributed as a Poisson process
+@testskip @testset "PoissonInput" begin
+    ρ₀ = 0.1
+    λ = 0.2
+    pI = PoissonInput(ρ₀, (t; dt) -> λ)
+    lasttime = 0
+    outputs = Int[] 
+    for t in 1:10_000
+        if (pI(t) > 0) 
+            push!(outputs, t - lasttime) # Store the time difference between the last time a spike was observed and now
+            lasttime = t # Update the time when last spike was observed
+        end
+    end
+    ds = Exponential(λ)
+    ExactOneSampleKSTest(outputs, ds) # Test if sample outputs is from same distribution
+end

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -8,7 +8,8 @@ end
 
 # Assert frequency constructor matches the rate constructor
 @testset "ConstantRate Constructors" begin
-    freq, dt = rand(), rand()
+    freq = rand()
+    freq == 0.01 ? dt = rand() * 0.01 : dt = rand()
     rate = freq * dt
     @test ConstantRate(freq, dt).rate == ConstantRate(rate).rate
 end

--- a/test/input-test.jl
+++ b/test/input-test.jl
@@ -1,96 +1,26 @@
-using SpikingNN
-using Statistics
-using Test
-
-@testset "input" begin
-
-    @testset "LIF SpikeCount" begin
-        # LIF params
-        τm = 100
-        vreset = 0.0
-        vth = 0.1
-        R = 1.75
-
-        # Input spike train params
-        rate = 0.05
-        T = 1000
-
-        lif = Neuron(QueuedSynapse(Synapse.Delta()), LIF(τm, vreset, R), Threshold.Ideal(vth))
-        input = ConstantRate(rate)
-
-
-        spikescount = []
-        for i in 1:T
-            spikes = excite!(lif, input, T)
-            push!(spikescount, length(spikes))
-        end
-
-        avgspikecount = mean(spikescount)/T
-
-
-        @test Float32(round(avgspikecount,digits = 2)) == input.rate
-    end
-
-    @testset "SRM SpikeCount" begin
-
-        # SRM0 params
-        η₀ = 5.0
-        τᵣ = 1.0
-        vth = 0.5
-
-        # Input spike train params
-        rate = 0.01
-        T = 1000
-
-        srm = Neuron(QueuedSynapse(Synapse.Alpha()), SRM0(η₀, τᵣ), Threshold.Ideal(vth))
-        input = ConstantRate(rate)
-
-
-        spikescount = []
-        for i in 1:T
-            spikes = excite!(srm, input, T)
-            push!(spikescount, length(spikes))
-        end
-
-        avgspikecount = mean(spikescount)/T
-
-        @test Float32(round(avgspikecount,digits = 2)) == input.rate
-        
-    end
-
-   # Assert frequency constructor matches the rate constructor
-   @testset "ConstantRate Constructor" begin
-
-    freq = 0.05
-    dt = 1.0
-    rate = freq * dt
-
-    @test ConstantRate(freq, dt).rate == ConstantRate(rate).rate
-
-    end
-
-    @testset "StepCurrent" begin
-
-        τ = 10
-
-        stepcurrent = StepCurrent(τ)
-
-        let
-            flag = true
-
-            for t in 0:100
-                if t <= τ
-                    evaluate!(stepcurrent, t) != 0 ? flag = false : flag = true
-                        
-                else
-                    (evaluate!(stepcurrent, t) > 0) != true ? flag = false : flag = true
-                end
-            end     
-
-            @test flag == true
-        end
-    end
-
-
+# Averaging the spike count of ConstantRate over a fixed window of time should be ConstantRate.rate
+@testset "ConstantRate" begin
+    T = 10_000
+    rate = rand()
+    input = ConstantRate(rate)
+    @test isapprox(count(x -> x > 0, [input(t) for t in 1:T]) / T, rate, atol=0.005)
 end
 
+# Assert frequency constructor matches the rate constructor
+@testset "ConstantRate Constructors" begin
+    freq, dt = rand(), rand()
+    rate = freq * dt
+    @test ConstantRate(freq, dt).rate == ConstantRate(rate).rate
+end
+
+# A StepCurrent should be zero < threshold time and positive > threshold time
+@testset "StepCurrent" begin
+    τ = 10
+    T = 25
+    stepcurrent = StepCurrent(τ)
+    prethresh = [stepcurrent(t) for t in 1:τ]
+    postthresh = [stepcurrent(t) for t in (τ + 1):T]
+
+    @test all(x -> x == 0, prethresh)
+    @test all(x -> x > 0, postthresh)    
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,9 +23,13 @@ testfiles = [
     "stdp-test.jl"
 ]
 
-@testset "SpikingNN.jl" begin
+@testset "VisualRegressionTests.jl" begin
     ENV["GKSwstype"] = "100"
     for testfile in testfiles
         include(testfile)
     end
+end
+
+@testset "inputs.jl" begin
+    include("input-test.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,13 +23,13 @@ testfiles = [
     "stdp-test.jl"
 ]
 
-@testset "VisualRegressionTests.jl" begin
+@testset "Visual Regression Tests" begin
     ENV["GKSwstype"] = "100"
     for testfile in testfiles
         include(testfile)
     end
 end
 
-@testset "inputs.jl" begin
+@testset "Input Models" begin
     include("input-test.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Plots
 using VisualRegressionTests
 using SpikingNN
 using Test
+using Distributions
+using HypothesisTests
 
 # environment settings
 isci = "CI" ∈ keys(ENV)


### PR DESCRIPTION
Fix #14 
@darsnack
- [X] Averaging the spike count of `ConstantRate` over a fixed window of time should be `ConstantRate.rate`
- [X] The frequency constructor for `ConstantRate` should match the rate constructor
- [X] A `StepCurrent` should be zero < threshold time and positive >= threshold time
- [ ] The spikes of a inhomogeneous Poisson input with a constant λ should be distributed as a Poisson process

I am a bit confused on:
>  positive >= threshold time

was this supposed to be
>  positive > threshold time